### PR TITLE
Fix capitalization of module

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -11,7 +11,7 @@ import * as Net from 'net';
 import * as ChildProcess from 'child_process';
 import {
     LanguageClient, LanguageClientOptions, SettingMonitor, ServerOptions, StreamInfo
-} from 'VSCode-languageclient';
+} from 'vscode-languageclient';
 
 PortFinder.basePort = 55747;
 


### PR DESCRIPTION
npm installs the module in lowercase form, so referring to it in any other capitalization breaks on case-sensitive file systems.
